### PR TITLE
Fix markdown component not updating when data becomes empty string

### DIFF
--- a/lib/markdown/markdown.component.ts
+++ b/lib/markdown/markdown.component.ts
@@ -47,7 +47,7 @@ export class MarkdownComponent implements OnInit {
 
   @Input()
   set data(value: string) {
-    if (value) {
+    if (value !== undefined) {
       this._data = value;
       this.onDataChange(value);
     }
@@ -55,7 +55,7 @@ export class MarkdownComponent implements OnInit {
 
   // on input
   onDataChange(data: string) {
-    if (data) {
+    if (data !== undefined) {
       this.el.nativeElement.innerHTML = this.mdService.compile(data);
     } else {
       this.el.nativeElement.innerHTML = "";


### PR DESCRIPTION
This fixes #119. The problem is that empty strings are falsey in JavaScript, so using `if (value)` to check for `undefined` also means that the code in the if statement will not run if `value` is an empty string.