### PR TITLE
Feature: Sanitize HTML

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -126,7 +126,7 @@
       "root": "projects/ngx-md",
       "sourceRoot": "projects/ngx-md/src",
       "projectType": "library",
-      "prefix": "lib",
+      "prefix": "ngx",
       "architect": {
         "build": {
           "builder": "@angular-devkit/build-ng-packagr:build",

--- a/projects/ngx-md/src/lib/ngx-md.component.spec.ts
+++ b/projects/ngx-md/src/lib/ngx-md.component.spec.ts
@@ -65,6 +65,24 @@ describe('NgxMdComponent', () => {
     });
   });
 
+  describe('XSS protection', () => {
+    it('should call service with sanitize enabled', () => {
+      spyOn(markdownService, 'compile');
+
+      component.sanitizeHtml = true;
+      component.data = 'Foo';
+
+      expect(markdownService.compile).toHaveBeenCalledWith('Foo', true);
+    });
+    it('should call service with sanitize disabled', () => {
+      spyOn(markdownService, 'compile');
+
+      component.sanitizeHtml = false;
+      component.data = 'Bar';
+
+      expect(markdownService.compile).toHaveBeenCalledWith('Bar', false);
+    });
+  });
 });
 
 @Component({ selector: 'ngx-md-host-for-test', template: '' })

--- a/projects/ngx-md/src/lib/ngx-md.component.spec.ts
+++ b/projects/ngx-md/src/lib/ngx-md.component.spec.ts
@@ -39,7 +39,7 @@ describe('NgxMdComponent', () => {
 
   describe('ngAfterViewInit', () => {
     it('should call `onPathChange` when [path] is provided', () => {
-      spyOn(component,'onPathChange');
+      spyOn(component, 'onPathChange');
       component.path = 'paht/to/file.md';
       component.ngAfterViewInit();
       expect(component.onPathChange).toHaveBeenCalled();
@@ -67,7 +67,7 @@ describe('NgxMdComponent', () => {
 
 });
 
-@Component({ selector: 'host-for-test', template: '' })
+@Component({ selector: 'ngx-md-host-for-test', template: '' })
 class HostComponent {
 }
 

--- a/projects/ngx-md/src/lib/ngx-md.component.spec.ts
+++ b/projects/ngx-md/src/lib/ngx-md.component.spec.ts
@@ -38,7 +38,7 @@ describe('NgxMdComponent', () => {
   });
 
   describe('ngAfterViewInit', () => {
-    it('should call `onPathChange` when [path] is provieded', () => {
+    it('should call `onPathChange` when [path] is provided', () => {
       spyOn(component,'onPathChange');
       component.path = 'paht/to/file.md';
       component.ngAfterViewInit();

--- a/projects/ngx-md/src/lib/ngx-md.component.ts
+++ b/projects/ngx-md/src/lib/ngx-md.component.ts
@@ -10,6 +10,9 @@ import * as Prism from 'prismjs';
     styles: [
         `.token.operator, .token.entity, .token.url, .language-css .token.string, .style .token.string {
             background: none;
+        }
+        .md-checkbox{
+            vertical-align: middle; margin: 0 0.2em 0.25em -1.6em; font-size: 16px;
         }`
     ]
 })
@@ -25,8 +28,6 @@ export class NgxMdComponent implements  AfterViewInit {
         private _el: ElementRef,
         @Inject(PLATFORM_ID) private platformId: string
     ) { }
-
-   
 
     @Input()
     set path(value: string) {
@@ -104,6 +105,7 @@ export class NgxMdComponent implements  AfterViewInit {
         if (this._ext === 'md' || !this.path) {
             let isCodeBlock = false;
             return raw.split('\n').map((line: string) => {
+                // If the first non-blank chars are an opening/closing code block, toggle the flag
                 if (this.trimLeft(line).substring(0, 3) === '```') {
                     isCodeBlock = !isCodeBlock;
                 }

--- a/projects/ngx-md/src/lib/ngx-md.component.ts
+++ b/projects/ngx-md/src/lib/ngx-md.component.ts
@@ -46,10 +46,16 @@ export class NgxMdComponent implements  AfterViewInit {
     }
 
 
+    /**
+     * Boolean indicating if the markdown content should be sanitized to avoid script injections
+     */
+    @Input() public sanitizeHtml = true;
+
+
     // on input
     onDataChange(data: string) {
       if (data) {
-        this._el.nativeElement.innerHTML = this._mdService.compile(data);
+        this._el.nativeElement.innerHTML = this._mdService.compile(data, this.sanitizeHtml);
       } else {
         this._el.nativeElement.innerHTML = '';
       }
@@ -69,7 +75,7 @@ export class NgxMdComponent implements  AfterViewInit {
 
     processRaw() {
       this._md = this.prepare(decodeHtml(this._el.nativeElement.innerHTML));
-      this._el.nativeElement.innerHTML = this._mdService.compile(this._md);
+      this._el.nativeElement.innerHTML = this._mdService.compile(this._md, this.sanitizeHtml);
       this.highlightContent(false);
     }
 
@@ -81,7 +87,7 @@ export class NgxMdComponent implements  AfterViewInit {
         this._mdService.getContent(this._path)
             .subscribe(data => {
                 this._md = this._ext !== 'md' ? '```' + this._ext + '\n' + data + '\n```' : data;
-                this._el.nativeElement.innerHTML = this._mdService.compile(this.prepare(this._md));
+                this._el.nativeElement.innerHTML = this._mdService.compile(this.prepare(this._md), this.sanitizeHtml);
                 this.highlightContent(false);
             },
             err => this.handleError);

--- a/projects/ngx-md/src/lib/ngx-md.service.spec.ts
+++ b/projects/ngx-md/src/lib/ngx-md.service.spec.ts
@@ -75,14 +75,31 @@ describe('NgxMdService', () => {
   );
 
   describe('XSS protection', () => {
-    it('should not change safe links', () => {
-      expect(markdownService.compile('[test](foo)').trim()).toEqual('<p><a href="foo">test</a></p>');
-      expect(markdownService.compile('[test](http://example.com)').trim()).toEqual('<p><a href="http://example.com">test</a></p>');
-      expect(markdownService.compile('[test](mailto:foo@example.com)').trim()).toEqual('<p><a href="mailto:foo@example.com">test</a></p>');
+    describe('Sanitize enabled', () => {
+      it('should not change safe links', () => {
+        expect(markdownService.compile('[test](foo)').trim())
+          .toEqual('<p><a href="foo">test</a></p>');
+        expect(markdownService.compile('[test](http://example.com)').trim())
+          .toEqual('<p><a href="http://example.com">test</a></p>');
+        expect(markdownService.compile('[test](mailto:foo@example.com)').trim())
+          .toEqual('<p><a href="mailto:foo@example.com">test</a></p>');
+      });
+      it('should change unsafe links', () => {
+        expect(markdownService.compile('[Click Me](javascript:alert(&#39;Injected!&#39;%29)').trim())
+          .toEqual('<p><a href="unsafe:javascript:alert(\'Injected!\'%29">Click Me</a></p>');
+      });
     });
-    it('should change unsafe links', () => {
-      expect(markdownService.compile('[Click Me](javascript:alert(&#39;Injected!&#39;%29)').trim())
-        .toEqual('<p><a href="unsafe:javascript:alert(\'Injected!\'%29">Click Me</a></p>');
+    describe('Sanitize disabled', () => {
+      it('should not change safe links', () => {
+        expect(markdownService.compile('[test](foo)', false).trim())
+          .toEqual('<p><a href="foo">test</a></p>');
+        expect(markdownService.compile('[test](http://example.com)', false).trim())
+          .toEqual('<p><a href="http://example.com">test</a></p>');
+        expect(markdownService.compile('[test](mailto:foo@example.com)', false).trim())
+          .toEqual('<p><a href="mailto:foo@example.com">test</a></p>');
+        expect(markdownService.compile('[Click Me](javascript:alert(&#39;Injected!&#39;%29)', false).trim())
+          .toEqual('<p><a href="javascript:alert(&#39;Injected!&#39;%29">Click Me</a></p>');
+      });
     });
   });
 });

--- a/projects/ngx-md/src/lib/ngx-md.service.spec.ts
+++ b/projects/ngx-md/src/lib/ngx-md.service.spec.ts
@@ -14,67 +14,63 @@ import {
 import { NgxMdService } from './ngx-md.service'
 import { Observable, of } from 'rxjs'
 
-let httpClient: HttpClient
-let httpTestingController: HttpTestingController
-
 describe('NgxMdService', () => {
+  let httpMock: HttpTestingController
+  let markdownService: NgxMdService
+  
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
       providers: [NgxMdService]
     })
+    
+    // Inject the http service and test controller for each test
+    httpMock = TestBed.get(HttpTestingController)
   })
-
+  afterEach(() => {
+    httpMock.verify();
+  });
+  
   it(
     'should be created',
     inject([NgxMdService], (service: NgxMdService) => {
       expect(service).toBeTruthy()
     })
   )
-})
-
-beforeEach(() => {
-  TestBed.configureTestingModule({
-    imports: [HttpClientTestingModule],
-    providers: [NgxMdService]
-  })
-
-  // Inject the http service and test controller for each test
-  httpClient = TestBed.get(HttpClient)
-  httpTestingController = TestBed.get(HttpTestingController)
-})
-
-describe('Markdown Service', () => {
-  let markdownService: NgxMdService
-  let response: HttpResponse<any>
-
+  
   beforeEach(() => {
     markdownService = TestBed.get(NgxMdService)
     const mockResponse = `Data`
   })
-
-  it('should call http service to get [path] content', () => {
-    spyOn(httpClient, 'get').and.returnValue(of())
-
-    const mockSrc = 'src-x'
-
-    markdownService.getContent(mockSrc)
-
-    expect(httpClient.get).toHaveBeenCalledWith(mockSrc)
+  
+  it('should call http service to get [path] content', () => {    
+    const TEST_DATA = 'Foo';
+    const TEST_URL = 'src-x';
+    
+    markdownService.getContent(TEST_URL).subscribe(received => {
+      expect(received).toEqual(TEST_DATA);
+    })
+    
+    const req = httpMock.expectOne(TEST_URL);
+    expect(req.request.method).toBe('GET');
+    req.flush(TEST_DATA);
   })
-
+  
   it(
     'should return data',
     async(() => {
       spyOn(markdownService, 'extractData')
 
-      const observable = markdownService.getContent('src-x')
-
-      observable.subscribe(responseData => {
-        expect(markdownService.extractData).toHaveBeenCalledWith(
-          response,
-          jasmine.any(Number)
-        )
+      const TEST_DATA = 'Foo';
+      const TEST_URL = 'src-x';
+      
+      markdownService.getContent(TEST_URL).subscribe(responseData => {
+        expect(markdownService.extractData).toHaveBeenCalledWith(TEST_DATA)
       })
+
+      const req = httpMock.expectOne(TEST_URL);
+      expect(req.request.method).toBe('GET');
+      req.flush(TEST_DATA);
     })
   )
 })

--- a/projects/ngx-md/src/lib/ngx-md.service.spec.ts
+++ b/projects/ngx-md/src/lib/ngx-md.service.spec.ts
@@ -73,4 +73,16 @@ describe('NgxMdService', () => {
       req.flush(TEST_DATA);
     })
   );
+
+  describe('XSS protection', () => {
+    it('should not change safe links', () => {
+      expect(markdownService.compile('[test](foo)').trim()).toEqual('<p><a href="foo">test</a></p>');
+      expect(markdownService.compile('[test](http://example.com)').trim()).toEqual('<p><a href="http://example.com">test</a></p>');
+      expect(markdownService.compile('[test](mailto:foo@example.com)').trim()).toEqual('<p><a href="mailto:foo@example.com">test</a></p>');
+    });
+    it('should change unsafe links', () => {
+      expect(markdownService.compile('[Click Me](javascript:alert(&#39;Injected!&#39;%29)').trim())
+        .toEqual('<p><a href="unsafe:javascript:alert(\'Injected!\'%29">Click Me</a></p>');
+    });
+  });
 });

--- a/projects/ngx-md/src/lib/ngx-md.service.spec.ts
+++ b/projects/ngx-md/src/lib/ngx-md.service.spec.ts
@@ -1,76 +1,76 @@
-import { TestBed, async, inject } from '@angular/core/testing'
+import { TestBed, async, inject } from '@angular/core/testing';
 import {
   HttpClientModule,
   HttpClient,
   HttpResponse,
   HttpXhrBackend,
   HttpBackend
-} from '@angular/common/http'
+} from '@angular/common/http';
 
 import {
   HttpClientTestingModule,
   HttpTestingController
-} from '@angular/common/http/testing'
-import { NgxMdService } from './ngx-md.service'
-import { Observable, of } from 'rxjs'
+} from '@angular/common/http/testing';
+import { NgxMdService } from './ngx-md.service';
+import { Observable, of } from 'rxjs';
 
 describe('NgxMdService', () => {
-  let httpMock: HttpTestingController
-  let markdownService: NgxMdService
-  
+  let httpMock: HttpTestingController;
+  let markdownService: NgxMdService;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       providers: [NgxMdService]
-    })
-    
+    });
+
     // Inject the http service and test controller for each test
-    httpMock = TestBed.get(HttpTestingController)
-  })
+    httpMock = TestBed.get(HttpTestingController);
+  });
   afterEach(() => {
     httpMock.verify();
   });
-  
+
   it(
     'should be created',
     inject([NgxMdService], (service: NgxMdService) => {
-      expect(service).toBeTruthy()
+      expect(service).toBeTruthy();
     })
-  )
-  
+  );
+
   beforeEach(() => {
-    markdownService = TestBed.get(NgxMdService)
-    const mockResponse = `Data`
-  })
-  
-  it('should call http service to get [path] content', () => {    
+    markdownService = TestBed.get(NgxMdService);
+    const mockResponse = `Data`;
+  });
+
+  it('should call http service to get [path] content', () => {
     const TEST_DATA = 'Foo';
     const TEST_URL = 'src-x';
-    
+
     markdownService.getContent(TEST_URL).subscribe(received => {
       expect(received).toEqual(TEST_DATA);
-    })
-    
+    });
+
     const req = httpMock.expectOne(TEST_URL);
     expect(req.request.method).toBe('GET');
     req.flush(TEST_DATA);
-  })
-  
+  });
+
   it(
     'should return data',
     async(() => {
-      spyOn(markdownService, 'extractData')
+      spyOn(markdownService, 'extractData');
 
       const TEST_DATA = 'Foo';
       const TEST_URL = 'src-x';
-      
+
       markdownService.getContent(TEST_URL).subscribe(responseData => {
-        expect(markdownService.extractData).toHaveBeenCalledWith(TEST_DATA)
-      })
+        expect(markdownService.extractData).toHaveBeenCalledWith(TEST_DATA);
+      });
 
       const req = httpMock.expectOne(TEST_URL);
       expect(req.request.method).toBe('GET');
       req.flush(TEST_DATA);
     })
-  )
-})
+  );
+});

--- a/projects/ngx-md/src/lib/ngx-md.service.ts
+++ b/projects/ngx-md/src/lib/ngx-md.service.ts
@@ -16,7 +16,10 @@ export class NgxMdService {
 
   // get the content from remote resource
   getContent(path: string): Observable<any> {
-      return this._http.get(path, {responseType: 'text'}).pipe(map(res => res), catchError(this.handleError))
+    return this._http.get(path, {responseType: 'text'})
+      .pipe(
+        map(res => this.extractData(res)),
+        catchError(this.handleError))
   }
 
    public get renderer() {
@@ -25,7 +28,7 @@ export class NgxMdService {
 
    // handle data
    public extractData(res: any): string {
-     return res.text() || '';
+     return res || '';
    }
 
    public setMarkedOptions(options: any) {

--- a/projects/ngx-md/src/lib/ngx-md.service.ts
+++ b/projects/ngx-md/src/lib/ngx-md.service.ts
@@ -51,8 +51,11 @@ export class NgxMdService {
   }
 
   // comple markdown to html
-  public compile(data: string) {
-    return this._domSanitizer.sanitize(SecurityContext.HTML, parse(data).trim());
+  public compile(data: string, sanitize = true) {
+    return this._domSanitizer.sanitize(
+      sanitize ? SecurityContext.HTML : SecurityContext.NONE,
+      parse(data).trim()
+    );
   }
 
   // handle error

--- a/projects/ngx-md/src/lib/ngx-md.service.ts
+++ b/projects/ngx-md/src/lib/ngx-md.service.ts
@@ -1,15 +1,19 @@
-import { Injectable } from '@angular/core';
+import { Injectable, SecurityContext } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { throwError, Observable } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 import { Renderer, setOptions, parse } from 'marked';
+import { DomSanitizer } from '@angular/platform-browser';
 
 @Injectable({
   providedIn: 'root'
 })
 export class NgxMdService {
   private _renderer: any = new Renderer();
-  constructor(private _http: HttpClient) {
+  constructor(
+    private _http: HttpClient,
+    private _domSanitizer: DomSanitizer
+  ) {
     this.extendRenderer();
     this.setMarkedOptions({});
   }
@@ -17,63 +21,65 @@ export class NgxMdService {
   // get the content from remote resource
   getContent(path: string): Observable<any> {
     return this._http.get(path, {responseType: 'text'})
-      .pipe(
-        map(res => this.extractData(res)),
-        catchError(this.handleError));
+    .pipe(
+      map(res => this.extractData(res)),
+      catchError(this.handleError)
+    );
   }
 
-   public get renderer() {
-     return this._renderer;
-   }
+  public get renderer() {
+    return this._renderer;
+  }
 
-   // handle data
-   public extractData(res: any): string {
-     return res || '';
-   }
+  // handle data
+  public extractData(res: any): string {
+    return res || '';
+  }
 
-   public setMarkedOptions(options: any) {
-     options = Object.assign({
-       gfm: true,
-       tables: true,
-       breaks: false,
-       pedantic: false,
-       sanitize: false,
-       smartLists: true,
-       smartypants: false
-     }, options);
-     options.renderer = this._renderer;
-     setOptions(options);
-   }
+  public setMarkedOptions(options: any) {
+    options = Object.assign({
+      gfm: true,
+      tables: true,
+      breaks: false,
+      pedantic: false,
+      sanitize: false,
+      smartLists: true,
+      smartypants: false
+    }, options);
+    options.renderer = this._renderer;
+    setOptions(options);
+  }
 
-   // comple markdown to html
-   public compile(data: string) {
-      return parse(data);
-   }
+  // comple markdown to html
+  public compile(data: string) {
+    return this._domSanitizer.sanitize(SecurityContext.HTML, parse(data).trim());
+  }
 
-   // handle error
-   private handleError(error: any): any {
-     let errMsg: string;
-     if (error instanceof fetch) {
-       const body = error.json() || '';
-       const err = body.error || JSON.stringify(body);
-       errMsg = `${error.status} - ${error.statusText || ''} ${err}`;
-     } else {
-       errMsg = error.message ? error.message : error.toString();
-     }
-     return throwError(errMsg);
-   }
+  // handle error
+  private handleError(error: any): any {
+    let errMsg: string;
+    if (error instanceof fetch) {
+      const body = error.json() || '';
+      const err = body.error || JSON.stringify(body);
+      errMsg = `${error.status} - ${error.statusText || ''} ${err}`;
+    } else {
+      errMsg = error.message ? error.message : error.toString();
+    }
+    return throwError(errMsg);
+  }
 
-   // extend marked render to support todo checkbox
-   private extendRenderer() {
-     this._renderer.listitem = function(text: string) {
+  // extend marked render to support todo checkbox
+  private extendRenderer() {
+    this._renderer.listitem = function(text: string) {
       if (/^\s*\[[x ]\]\s*/.test(text)) {
-      text = text
+        text = text
         .replace(/^\s*\[ \]\s*/, '<input type="checkbox" class="md-checkbox" disabled> ')
         .replace(/^\s*\[x\]\s*/, '<input type="checkbox" class="md-checkbox" checked disabled> ');
-          return '<li style="list-style: none">' + text + '</li>';
-        } else {
-          return '<li>' + text + '</li>';
-        }
-      };
-   }
+        return '<li style="list-style: none">' + text + '</li>';
+      } else {
+        return '<li>' + text + '</li>';
+      }
+    };
+  }
 }
+

--- a/projects/ngx-md/src/lib/ngx-md.service.ts
+++ b/projects/ngx-md/src/lib/ngx-md.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@angular/core'
+import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { throwError, Observable } from 'rxjs'
+import { throwError, Observable } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 import { Renderer, setOptions, parse } from 'marked';
 
@@ -19,7 +19,7 @@ export class NgxMdService {
     return this._http.get(path, {responseType: 'text'})
       .pipe(
         map(res => this.extractData(res)),
-        catchError(this.handleError))
+        catchError(this.handleError));
   }
 
    public get renderer() {
@@ -68,8 +68,8 @@ export class NgxMdService {
      this._renderer.listitem = function(text: string) {
       if (/^\s*\[[x ]\]\s*/.test(text)) {
       text = text
-        .replace(/^\s*\[ \]\s*/, '<input type="checkbox" style=" vertical-align: middle; margin: 0 0.2em 0.25em -1.6em; font-size: 16px; " disabled> ')
-        .replace(/^\s*\[x\]\s*/, '<input type="checkbox" style=" vertical-align: middle; margin: 0 0.2em 0.25em -1.6em; font-size: 16px; " checked disabled> ');
+        .replace(/^\s*\[ \]\s*/, '<input type="checkbox" class="md-checkbox" disabled> ')
+        .replace(/^\s*\[x\]\s*/, '<input type="checkbox" class="md-checkbox" checked disabled> ');
           return '<li style="list-style: none">' + text + '</li>';
         } else {
           return '<li>' + text + '</li>';

--- a/projects/ngx-md/tslint.json
+++ b/projects/ngx-md/tslint.json
@@ -4,13 +4,13 @@
         "directive-selector": [
             true,
             "attribute",
-            "lib",
+            "ngx-md",
             "camelCase"
         ],
         "component-selector": [
             true,
             "element",
-            "lib",
+            "ngx-md",
             "kebab-case"
         ]
     }


### PR DESCRIPTION
By default, the `NgxMdService.compile` method sanitize the parsed content in the security context for HTML. This behavior can be disabled by setting the optional 2nd parameter to `false`.

The `NgxMdComponent` has a new *boolean* input `sanitizeHtml`, that controls if calls to the service are done with the sanitization behavior.

---

This PR includes various little linting edits (including in `angular.json`. Also, the `extendRenderer` service method does not render checkboxes with inline styles, because styles are moved to the `NgxMdComponent`.

Related to #152