### PR TITLE
Add support for Angular Universal

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,6 +8,7 @@ env:
 test_task:
   node_modules_cache:
     folder: node_modules
-    populate_script: npm install
+    fingerprint_script: cat yarn.lock
+    populate_script: yarn install
   lib_test_script: npm run ci.travis.lib
   demo_test_script: npm run ci.travis.demo

--- a/libs/ngx-md/src/lib/ngx-md.component.ts
+++ b/libs/ngx-md/src/lib/ngx-md.component.ts
@@ -13,6 +13,7 @@ import { isPlatformBrowser } from '@angular/common';
 import * as Prism from 'prismjs';
 import { Subscribable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
+import { decode } from 'he';
 
 @Component({
   selector: 'markdown,[Markdown],ngx-md,[NgxMd]',
@@ -47,7 +48,7 @@ export class NgxMdComponent implements AfterViewInit {
     public _mdService: NgxMdService,
     public _el: ElementRef,
     @Inject(PLATFORM_ID) public platformId: string
-  ) {}
+  ) { }
 
   @Input()
   set path(value: string) {
@@ -95,7 +96,7 @@ export class NgxMdComponent implements AfterViewInit {
   }
 
   processRaw() {
-    this._md = this.prepare(decodeHtml(this._el.nativeElement.innerHTML));
+    this._md = this.prepare(decode(this._el.nativeElement.innerHTML));
     this._el.nativeElement.innerHTML = this._mdService.compile(
       this._md,
       this.sanitizeHtml
@@ -175,11 +176,4 @@ export class NgxMdComponent implements AfterViewInit {
       Prism.highlightAll(async);
     }
   }
-}
-
-function decodeHtml(html: string) {
-  // https://stackoverflow.com/a/7394787/588521
-  const txt = document.createElement('textarea');
-  txt.innerHTML = html;
-  return txt.value;
 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@angular/platform-browser-dynamic": "^8.2.14",
     "@angular/router": "^8.2.14",
     "core-js": "^3.6.0",
+    "he": "^1.2.0",
     "json-align": "^0.1.0",
     "lodash": "^4.17.15",
     "marked": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5614,6 +5614,11 @@ hasha@5.1.0:
     is-stream "^2.0.0"
     type-fest "^0.8.0"
 
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
This is a rewrite of #183 (thanks @dirkgroenen) that should pass CI.

The modification from #183 is to use update `yarn.lock` instead of `npm-shrinkwrap.json`.

Suggest getting rid of `npm-shrinkwrap.json` to avoid confusion in the future.

> `document` is not available during Server Side Rendering. By using the 'he' library we're no longer depending on the DOM to exist, adding support for Angular Universal.
> -- @dirkgroenen, #183

Closes #183, #149
