### PR TITLE
Fix CI caching issue

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,6 +8,7 @@ env:
 test_task:
   node_modules_cache:
     folder: node_modules
-    populate_script: npm install
+    fingerprint_script: cat yarn.lock
+    populate_script: yarn install
   lib_test_script: npm run ci.travis.lib
   demo_test_script: npm run ci.travis.demo


### PR DESCRIPTION
Change to yarn to install CI deps (npm's lock file is empty and not used).

Add fingerprint_script as described in the Cirrus CI docs: https://cirrus-ci.org/guide/writing-tasks/